### PR TITLE
use req.ip instead of X-Forwarded-For

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright (c) 2011 Jared Hanson
+Copyright (c) 2014 Eugenio Pace
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,4 +1,35 @@
-passport-ip
-===========
+An IP based authentication passport strategy.
 
-An IP based authentication passport strategy
+## Installation
+
+npm i eugeniop/passport-ip --save
+
+## Usage
+
+Register the strategy in passport as follows:
+
+```javascript
+var passport = require('passport');
+var IpStrategy = require('passport-ip').Strategy;
+
+passport.use(new IpStrategy({
+  range: '10.0.0.0/8'
+}, function(profile, done){
+  done(null, profile);
+  //profile.id is the ip address.
+}));
+```
+
+## Configuration behind a proxy
+
+If you are running your express application behind a proxy that you trust:
+
+```javascript
+app.enable('trust proxy');
+```
+
+Then passport-ip will use the X-Forwarded-For header.
+
+## License
+
+MIT 2014 Eugenio Pace

--- a/lib/passport-ip/index.js
+++ b/lib/passport-ip/index.js
@@ -8,7 +8,7 @@ var Strategy = require('./strategy')
 /**
  * Framework version.
  */
-require('pkginfo')(module, 'version');
+exports.version = require('../../package').version;
 
 /**
  * Expose constructors.

--- a/lib/passport-ip/strategy.js
+++ b/lib/passport-ip/strategy.js
@@ -30,7 +30,7 @@ var passport = require('passport')
  *
  *     passport.use(new IPStrategy(
  *       function(client, done) {
- *         console.log(client.id); //equal to the IP address  
+ *         console.log(client.id); //equal to the IP address
  *         done(null, {user_id: client.id});
  *         });
  *       }
@@ -49,7 +49,7 @@ function Strategy(options, verify) {
   if(!options.range){ throw new Error('IP authentication strategy requires an IP Range parameter'); }
 
   this._range = options.range;
-  
+
   passport.Strategy.call(this);
   this.name = 'ip';
   this._verify = verify;
@@ -69,34 +69,31 @@ util.inherits(Strategy, passport.Strategy);
  * @api protected
  */
 Strategy.prototype.authenticate = function(req) {
-  if(!req.query || !req.query.code)
-  {
+  function verified(err, user) {
+    if (err) { return self.error(err); }
+    if (!user) { return self.fail(new Error('No user in verified callback.')); }
+    self.success(user);
+  }
+
+  if(!req.query || !req.query.code) {
     //First time we force a redirect to kick-off the 2nd stage of Auth0 authN
     this.redirect('/login/callback?code=dummy');
-  }
-  else
-  {
+  } else {
     //we are back from the redirect. Check the IP address
-    var clientIP = req.headers['x-forwarded-for'];
+    if (!req.ip) {
+      return this.fail(new BadRequestError("Unknown ip address."));
+    }
 
-    if(!clientIP) { return this.fail(new BadRequestError("No x-forwarded-for header.")); } 
-
-    if(!range_check.in_range(clientIP, this._range))
-    {
-      return this.fail("Client IP: " + clientIP + ", is outside the range specified for this strategy.");
+    if (!range_check.in_range(req.ip, this._range)) {
+      return this.fail("Client IP: " + req.ip + ", is outside the range specified for this strategy.");
     }
 
     var self = this;
 
-    function verified(err, user) {
-      if (err) { return self.error(err); }
-      if (!user) { return self.fail(new Error('No user in verified callback.')); }
-      self.success(user);
-    }
-  
     var client = {
-      id: clientIP,
-      provider: this.name
+      id:       req.ip,
+      provider: this.name,
+      displayName: req.ip
     };
 
     if(this._username){
@@ -108,11 +105,11 @@ Strategy.prototype.authenticate = function(req) {
     } else {
       this._verify(client, verified);
     }
-  }  
-}
+  }
+};
 
 
 /**
  * Expose `Strategy`.
- */ 
+ */
 module.exports = Strategy;

--- a/package.json
+++ b/package.json
@@ -13,15 +13,14 @@
   },
   "bugs": {
     "url": "http://github.com/eugeniop/passport-ip/issues"
-  },  
+  },
   "main": "./lib/passport-ip",
   "dependencies": {
-    "pkginfo": "0.2.x",
     "passport": "~0.1.1",
     "range_check": "0.0.1"
   },
   "devDependencies": {
-    "vows": "0.6.x"
+    "vows": "~0.8.1"
   },
   "scripts": {
     "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"
@@ -42,7 +41,6 @@
     "authn",
     "authentication"
   ],
-  
   "readme": "README.md",
   "homepage": "https://github.com/eugeniop/passport-ip"
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,18 +1,18 @@
 var vows = require('vows');
 var assert = require('assert');
 var util = require('util');
-var local = require('passport-ip');
+var ip = require('passport-ip');
 
-vows.describe('passport-local').addBatch({
-  
+vows.describe('passport-ip').addBatch({
+
   'module': {
     'should report a version': function (x) {
-      assert.isString(local.version);
+      assert.isString(ip.version);
     },
-    
+
     'should export BadRequestError': function (x) {
-      assert.isFunction(local.BadRequestError);
+      assert.isFunction(ip.BadRequestError);
     },
   },
-  
+
 }).export(module);

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -6,17 +6,17 @@ var BadRequestError = require('passport-ip/errors/badrequesterror');
 
 
 vows.describe('ipStrategy').addBatch({
-  
+
   'strategy': {
     topic: function() {
       return new Strategy({range:'1.1.1.1'}, function(){});
     },
-    
+
     'should be named session': function (strategy) {
       assert.equal(strategy.name, 'ip');
     },
   },
-  
+
   'strategy handling a request in range': {
     topic: function() {
       var strategy = new Strategy({range:'1.1.1.1/5'}, function(){});
@@ -26,13 +26,13 @@ vows.describe('ipStrategy').addBatch({
           assert.equal(url, '/login/callback?code=dummy');
           strategy.authenticate( {
                                   query: { code: 'dummy' },
-                                  headers: {'x-forwarded-for': '1.1.1.1'}
+                                  ip: '1.1.1.1'
                                  });
       };
 
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -42,21 +42,21 @@ vows.describe('ipStrategy').addBatch({
 
         strategy.success = function(user) {
           self.callback(null, user);
-        }
+        };
 
         strategy.fail = function() {
           self.callback(new Error('should-not-be-called'));
-        }
-        
+        };
+
         strategy._verify = function(client, done) {
           done(null, { user_id: client.id });
-        }
-        
+        };
+
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -66,42 +66,47 @@ vows.describe('ipStrategy').addBatch({
     },
   },
 
-    'strategy handling a request in multiple ranges': {
+  'strategy handling a request in multiple ranges': {
     topic: function() {
-      var strategy = new Strategy({range:'1.1.1.1/5,10.0.0.0/10'.split(",")}, function(){});
+      var strategy = new Strategy({
+        range: ['1.1.1.1/5' , '10.0.0.0/10']
+      }, function(err, profile, done) {
+
+      });
 
       //Mock
       strategy.redirect = function(url) {
         assert.equal(url, '/login/callback?code=dummy');
-        strategy.authenticate( {
-                                  query: { code: 'dummy' },
-                                  headers: {'x-forwarded-for': '1.1.1.1'}
-                                 });
+        strategy.authenticate({ query: { code: 'dummy' }, ip: '1.1.1.1' });
         return strategy;
       };
+
+      return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
+        var req = {};
 
         strategy.success = function(user) {
           self.callback(null, user);
-        }
+        };
 
         strategy.fail = function() {
-          self.callback(new Error('should-not-be-called'));
-        }
-        
+          throw new Error('should-not-be-called');
+        };
+
         strategy._verify = function(client, done) {
           done(null, { user_id: client.id });
-        }
-        
+        };
+
         process.nextTick(function () {
           strategy.authenticate(req);
         });
+
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -113,18 +118,23 @@ vows.describe('ipStrategy').addBatch({
 
   'strategy handling a request in multiple ranges with an optional username': {
     topic: function() {
-      var strategy = new Strategy({range:'1.1.1.1/5,10.0.0.0/10'.split(","), username: '123'}, function(){});
+      var strategy = new Strategy({
+        range: ['1.1.1.1/5', '10.0.0.0/10'],
+        username: '123'
+      }, function(){});
 
       //Mock
       strategy.redirect = function(url) {
-          assert.equal(url, '/login/callback?code=dummy');
-          strategy.authenticate( {
-                                  query: { code: 'dummy' },
-                                  headers: {'x-forwarded-for': '1.1.1.1'}
-                                 });
+        assert.equal(url, '/login/callback?code=dummy');
+        strategy.authenticate({
+                                query: { code: 'dummy' },
+                                ip: '1.1.1.1'
+                               });
 
-          return strategy;
+        return strategy;
       };
+
+      return strategy;
     },
 
     'after augmenting with actions': {
@@ -134,22 +144,23 @@ vows.describe('ipStrategy').addBatch({
 
         strategy.success = function(user) {
           self.callback(null, user);
-        }
+        };
 
         strategy.fail = function() {
           self.callback(new Error('should-not-be-called'));
-        }
-        
+        };
+
         strategy._verify = function(client, done) {
           done(null, { user_id: client.id, username: client.username });
-        }
-        
-        req.headers = { 'x-forwarded-for': '1.1.1.1'};
+        };
+
+        req.ip = '1.1.1.1';
+
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -159,7 +170,7 @@ vows.describe('ipStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request off range fails': {
     topic: function() {
       var strategy = new Strategy({range:'1.1.1.1/5'}, function(){});
@@ -168,79 +179,81 @@ vows.describe('ipStrategy').addBatch({
           assert.equal(url, '/login/callback?code=dummy');
           strategy.authenticate( {
                                   query: { code: 'dummy' },
-                                  headers: {'x-forwarded-for': '192.168.1.6'}
+                                  ip: '192.168.1.6'
                                  });
       };
 
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
         var req = {};
         strategy.success = function(user) {
           self.callback(new Error('should-not-be-called'));
-        }
+        };
         strategy.fail = function() {
           self.callback(null);
-        }
-        
+        };
+
         strategy._verify = function(client, done) {
           self.callback(new Error('should-not-be-called'));
-        }
-        
+        };
+
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
       'should authenticate' : function(err, user) {
-         
+
       },
     },
   },
-  
+
   'strategy handling a request that encounters an error during verification': {
     topic: function() {
       var strategy = new Strategy({range: '1.1.1.1/2'}, function(){});
-      
+
       strategy.redirect = function(url) {
           assert.equal(url, '/login/callback?code=dummy');
           strategy.authenticate( {
                                   query: { code: 'dummy' },
-                                  headers: {'x-forwarded-for': '1.1.1.1'}
+                                  ip: '1.1.1.1'
                                  });
         return strategy;
       };
+
+      return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
         var req = {};
         strategy.success = function(user) {
           self.callback(new Error('should-not-be-called'));
-        }
+        };
         strategy.fail = function() {
           self.callback(new Error('should-not-be-called'));
-        }
+        };
         strategy.error = function(err) {
           self.callback(null, err);
-        }
-        
+        };
+
         strategy._verify = function(client, done) {
           done(new Error('something-went-wrong'));
-        }
-        
+        };
+
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should not call success or fail' : function(err, e) {
         assert.isNull(err);
       },
@@ -256,27 +269,27 @@ vows.describe('ipStrategy').addBatch({
 
       strategy.redirect = function(url) {
         assert.equal(url, '/login/callback?code=dummy');
-        strategy.authenticate( {
-                                  query: { code: 'dummy' },
-                                 });
+        strategy.authenticate( { query: { code: 'dummy' } });
         return strategy;
       };
+
+      return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
         var req = {};
         strategy.fail = function(info) {
           self.callback(null, info);
-        }
-        
+        };
+
         req.headers =  {} ;
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication' : function(err) {
         // fail action was called, resulting in test callback
         assert.isTrue(true);
@@ -287,7 +300,7 @@ vows.describe('ipStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy constructed without a verify callback': {
     'should throw an error': function (strategy) {
       assert.throws(function() { new Strategy() });


### PR DESCRIPTION
The `X-Forwarded-For` header might have more than one ip address comma separated.

After this change passport-ip will use `req.ip` which is the standard way of accesing the ip address in Express.js.

`req.ip` is the trusted ip address, either the remote connection address or the latest X-Forwareded-For ip depending on the `trust proxy` setting.

More info [here](http://expressjs.com/es/guide/behind-proxies.html).